### PR TITLE
[FEAT] 홈페이지 구현

### DIFF
--- a/src/data/mockUsers.ts
+++ b/src/data/mockUsers.ts
@@ -1,0 +1,76 @@
+import type { UserCardData } from '@/interfaces/user';
+
+export const mockUsers: UserCardData[] = [
+  {
+    id: '1',
+    userId: '1',
+    name: '차한잔',
+    age: 40,
+    teaScore: 4,
+    introduction: '안녕하세요~ 저는 요즘 운동과 식습관에 관심이 많습니다. 편하게 같이 얘기해봐요 ^^',
+    hashtags: ['일상', '취미', '사회']
+  },
+  {
+    id: '2',
+    userId: '2',
+    name: '녹차차',
+    age: 10,
+    teaScore: 5,
+    introduction: '여행과 맛집 탐방을 좋아해요! 새로운 사람들과의 만남을 기대합니다.',
+    hashtags: ['여행', '맛집', '패션']
+  },
+  {
+    id: '3',
+    userId: '3',
+    name: '홍차러버',
+    age: 50,
+    teaScore: 3,
+    introduction: '영화와 독서를 즐기며, 가끔 요리도 해봅니다. 편안한 대화를 나누고 싶어요.',
+    hashtags: ['영화', '독서', '요리']
+  },
+  {
+    id: '4',
+    userId: '4',
+    name: '차이',
+    age: 60,
+    teaScore: 4,
+    introduction: '건강한 라이프스타일을 추구하며, 스포츠와 요가에 관심이 많습니다.',
+    hashtags: ['건강', '스포츠', '요가']
+  },
+  {
+    id: '5',
+    userId: '5',
+    name: '차한잔',
+    age: 40,
+    teaScore: 4,
+    introduction: '안녕하세요~ 저는 요즘 운동과 식습관에 관심이 많습니다. 편하게 같이 얘기해봐요 ^^',
+    hashtags: ['일상', '취미', '사회']
+  },
+  {
+    id: '6',
+    userId: '6',
+    name: '차마니',
+    age: 20,
+    teaScore: 5,
+    introduction: '여행과 맛집 탐방을 좋아해요! 새로운 사람들과의 만남을 기대합니다.',
+    hashtags: ['여행', '맛집', '패션']
+  },
+  {
+    id: '7',
+    userId: '7',
+    name: '차차',
+    age: 30,
+    teaScore: 3,
+    introduction: '영화와 독서를 즐기며, 가끔 요리도 해봅니다. 편안한 대화를 나누고 싶어요.',
+    hashtags: ['영화', '독서', '요리']
+  },
+  {
+    id: '8',
+    userId: '8',
+    name: '차이',
+    age: 30,
+    teaScore: 4,
+    introduction: '건강한 라이프스타일을 추구하며, 스포츠와 요가에 관심이 많습니다.',
+    hashtags: ['건강', '스포츠', '요가']
+  }
+];

--- a/src/interfaces/interests.ts
+++ b/src/interfaces/interests.ts
@@ -4,12 +4,14 @@ export interface InterestCategory {
 }
 
 export const INTEREST_CATEGORIES: InterestCategory[] = [
-  { id: '취미', label: '취미' },
-  { id: '사회', label: '사회' },
+  { id: '맛집', label: '맛집' },
+  { id: '여행', label: '여행' },
+  { id: '패션', label: '패션' },
+  { id: '요리', label: '요리' },
+  { id: '영화', label: '영화' },
+  { id: '스마트기기', label: '스마트기기' },
   { id: '건강', label: '건강' },
-  { id: '진로', label: '진로' },
-  { id: '가족', label: '가족' },
-  { id: '기술', label: '기술' }
+  { id: '스포츠', label: '스포츠' }
 ] as const;
 
 export type InterestId = typeof INTEREST_CATEGORIES[number]['id'];

--- a/src/interfaces/user.ts
+++ b/src/interfaces/user.ts
@@ -1,0 +1,15 @@
+export interface UserCardData {
+  id: string;
+  userId: string;
+  name: string;
+  age: number;
+  profileImage?: string;
+  teaScore: number; // 찻잔지수
+  introduction: string;
+  hashtags: string[];
+}
+
+export interface UserCardProps {
+  user: UserCardData;
+  onClick?: (userId: string) => void;
+}

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,11 +1,16 @@
-import { useEffect } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { useLayout } from '@/services/hooks/useLayout';
+import { INTEREST_CATEGORIES } from '@/interfaces/interests';
+import { mockUsers } from '@/data/mockUsers';
+import UserCard from './_components/UserCard';
+import UserCardSkeleton from './_components/UserCardSkeleton';
 
 const Home = () => {
-  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const { setLayoutConfig } = useLayout();
+  const [selectedInterests, setSelectedInterests] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
 
   // 레이아웃 설정
   useEffect(() => {
@@ -13,6 +18,7 @@ const Home = () => {
       type: 'home',
       showHeader: true,
       showBottomBar: true,
+      onNotification: () => console.log('알림 혹은 다른 로직 추후 구현'),
     });
   }, [setLayoutConfig]);
 
@@ -32,13 +38,69 @@ const Home = () => {
     // console.log('토큰이 sessionStorage에 저장되었습니다.');
     }
   }, [searchParams]);
+
+  // 로딩 시뮬레이션 (실제 API 호출 시 교체)
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsLoading(false);
+    }, 2000); // 2초 후 로딩 완료
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  // 관심사 클릭 핸들러
+  const handleInterestClick = (interestId: string) => {
+    setSelectedInterests(prev => {
+      if (prev.includes(interestId)) {
+        // 이미 선택된 경우 제거
+        return prev.filter(id => id !== interestId);
+      } else {
+        // 선택되지 않은 경우 추가
+        return [...prev, interestId];
+      }
+    });
+  };
+
+  // 유저 카드 클릭 핸들러
+  const handleUserCardClick = (userId: string) => {
+    console.log('유저 카드 클릭:', userId);
+    // 추후 상세 페이지로 이동하거나 모달 열기 등
+  };
   
   return (
     <div className="wrapper">
-      <div className="center">
-        <button className="btn-primary" onClick={() => navigate("/labs")}>
-          실험실로 이동하기 🧪🥼
-        </button>
+      <div className="home-container">
+        <div className="home-title">어떤 이야기로 차 한잔 하시겠어요?</div>
+        <div className="home-interests">
+          {INTEREST_CATEGORIES.map((interest) => (
+            <span 
+              key={interest.id} 
+              className={`home-interest-item ${selectedInterests.includes(interest.id) ? 'active' : ''}`}
+              onClick={() => handleInterestClick(interest.id)}
+            >
+              {interest.label}
+            </span>
+          ))}
+        </div>
+        
+        {/* 유저 카드 그리드 */}
+        <div className="user-cards-grid">
+          {isLoading ? (
+            // 로딩 중: 스켈레톤 UI
+            Array.from({ length: 6 }).map((_, index) => (
+              <UserCardSkeleton key={index} />
+            ))
+          ) : (
+            // 로딩 완료: 실제 데이터
+            mockUsers.map((user) => (
+              <UserCard 
+                key={user.id} 
+                user={user} 
+                onClick={handleUserCardClick}
+              />
+            ))
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/pages/Home/_components/UserCard.tsx
+++ b/src/pages/Home/_components/UserCard.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import type { UserCardProps } from '@/interfaces/user';
+
+const UserCard: React.FC<UserCardProps> = ({ user, onClick }) => {
+  const handleClick = () => {
+    if (onClick) {
+      onClick(user.id);
+    }
+  };
+
+  return (
+    <div className="user-card" onClick={handleClick}>
+      <div className="user-profile">
+        <div className="profile-image">
+          {user.profileImage ? (
+            <img src={user.profileImage} alt={`${user.name} 프로필`} />
+          ) : (
+            <div className="profile-placeholder">
+              <span>{user.name.charAt(0)}</span>
+            </div>
+          )}
+        </div>
+        <div className="user-info">
+          <span className="user-name">{user.name}</span>
+          <span className="user-age">{user.age}대</span><br/>
+          <span className="tea-score">찻잔지수<span className="tea-score-number">{user.teaScore}잔</span></span>
+        </div>
+      </div>
+      <div className="user-introduction">
+        {user.introduction}
+      </div>
+      <div className="user-hashtags">
+        {user.hashtags.map((tag, index) => (
+          <span key={index} className="hashtag">#{tag}</span>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default UserCard;

--- a/src/pages/Home/_components/UserCardSkeleton.tsx
+++ b/src/pages/Home/_components/UserCardSkeleton.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+const UserCardSkeleton: React.FC = () => {
+  return (
+    <div className="user-card-skeleton">
+      <div className="skeleton-profile">
+        <div className="skeleton-avatar"></div>
+        <div className="skeleton-info">
+          <div className="skeleton-name"></div>
+          <div className="skeleton-age"></div>
+          <div className="skeleton-tea-score"></div>
+        </div>
+      </div>
+      <div className="skeleton-introduction">
+        <div className="skeleton-line"></div>
+        <div className="skeleton-line"></div>
+        <div className="skeleton-line short"></div>
+      </div>
+      <div className="skeleton-hashtags">
+        <div className="skeleton-hashtag"></div>
+        <div className="skeleton-hashtag"></div>
+        <div className="skeleton-hashtag"></div>
+      </div>
+    </div>
+  );
+};
+
+export default UserCardSkeleton;

--- a/src/styles/_layout.scss
+++ b/src/styles/_layout.scss
@@ -14,7 +14,7 @@ body {
   width: 100%;
   margin: 0 auto;
   padding: variables.$spacing-md;
-  background-color: variables.$white;
+  background-color: variables.$background-color;
   min-height: 100vh;
 }
 

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -6,13 +6,16 @@ $font-heading: Helvetica, serif;
 
 // color
 $primary-color: #A7D783;
-$secondary-color: #ffc107;
+$secondary-color: #EAF4D3;
+$third-color: #F9F7D4;
 $danger-color: #f44336;
 $background-color: #FDFDF4;
 $gray: #c3c3c3;
 $black: #000000;
 $white: #ffffff;
+$outline-color: #93867A;
 $text-black: #2F2D2B;
+$text-gray: #7C7C7C;
 $disabled: #C5CCC7;
 
 // spacing

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -8,6 +8,7 @@
 @use "components/header";
 @use "pages/login";
 @use "pages/extra-info";
+@use "pages/home";
 
 #root {
   width: 100%;

--- a/src/styles/pages/home.scss
+++ b/src/styles/pages/home.scss
@@ -1,0 +1,270 @@
+@use "../variables";
+@use "../typography";
+
+.home-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding-top: 4px;
+}
+
+.home-title {
+  @extend .label;
+  padding-bottom: 12px;
+}
+
+.home-interests {
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+  width: 100%; // 부모 컨테이너의 100% 너비로 제한
+  overflow-x: auto; // 넘치는 부분은 스크롤로 처리
+  scrollbar-width: none;
+  padding-bottom: 16px;
+}
+
+.home-interest-item {
+  @extend .caption1;
+  background-color: variables.$secondary-color;
+  padding: 4px 8px;
+  border-radius: 2px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+  border: 1px solid variables.$outline-color;
+  
+  flex-shrink: 0;
+  
+  // 활성 상태 (클릭된 상태)
+  &.active {
+    background-color: variables.$primary-color;
+  }
+  
+  // 호버 효과
+  &:hover {
+    opacity: 0.8;
+  }
+}
+
+// 유저 카드 그리드
+.user-cards-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr; // 2열 그리드
+  gap: 12px;
+}
+
+// 유저 카드
+.user-card {
+  display: flex;
+  flex-direction: column;
+
+  background-color: variables.$white;
+  border: 1px solid variables.$secondary-color;
+  border-radius: 4px;
+  padding: 12px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  // width: 44.35vw;
+  // height: 25.11vh;
+  width: 173px;
+  height: 212px;
+  
+  &:hover {
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    transform: translateY(-2px);
+  }
+}
+
+// 프로필 영역
+.user-profile {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.profile-image {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  overflow: hidden;
+  flex-shrink: 0;
+  
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+.profile-placeholder {
+  width: 100%;
+  height: 100%;
+  background-color: variables.$gray;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: variables.$white;
+  font-weight: 500;
+}
+
+.user-info {
+  flex: 1;
+  min-width: 0; // 텍스트 오버플로우 방지
+}
+
+.user-name {
+  @extend .caption1;
+  margin-bottom: 2px;
+  margin-right: 8px;
+}
+
+.user-age {
+  @extend .caption2;
+  color: variables.$text-gray;
+}
+
+.tea-score {
+  @extend .caption2;
+  padding: 4px;
+  border-radius: 2px;
+  background-color: variables.$secondary-color;
+  color: variables.$text-black;
+}
+
+.tea-score-number {
+  padding-left: 4px;
+  font-weight: 500;
+}
+
+// 자기소개
+.user-introduction {
+  @extend .caption1;
+  text-align: start;
+  display: -webkit-box;
+  line-clamp: 3; // 3줄로 제한
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+// 해시태그
+.user-hashtags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: auto; // 카드 하단으로 밀어내기
+}
+
+.hashtag {
+  @extend .caption2;
+  color: variables.$text-gray;
+}
+
+// 스켈레톤 UI
+.user-card-skeleton {
+  display: flex;
+  flex-direction: column;
+  background-color: variables.$white;
+  border: 1px solid variables.$outline-color;
+  border-radius: 4px;
+  padding: 12px;
+  width: 173px;
+  height: 212px;
+}
+
+.skeleton-profile {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.skeleton-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+}
+
+.skeleton-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.skeleton-name {
+  width: 60px;
+  height: 12px;
+  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+  border-radius: 2px;
+}
+
+.skeleton-age {
+  width: 40px;
+  height: 10px;
+  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+  border-radius: 2px;
+}
+
+.skeleton-tea-score {
+  width: 80px;
+  height: 10px;
+  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+  border-radius: 2px;
+}
+
+.skeleton-introduction {
+  margin-bottom: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.skeleton-line {
+  height: 10px;
+  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+  border-radius: 2px;
+  
+  &:nth-child(1) { width: 100%; }
+  &:nth-child(2) { width: 90%; }
+  &.short { width: 60%; }
+}
+
+.skeleton-hashtags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: auto;
+}
+
+.skeleton-hashtag {
+  width: 30px;
+  height: 8px;
+  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+  border-radius: 2px;
+  
+  &:nth-child(2) { width: 25px; }
+  &:nth-child(3) { width: 35px; }
+}
+
+// Shimmer 애니메이션
+@keyframes shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}


### PR DESCRIPTION
<!-- Github Isssue Num -->

# ISSUE-12
#12 

## Summary

- 홈 페이지에 사용자 프로필 카드를 2열 그리드로 표시하는 컴포넌트 구현
- 로딩 상태를 위한 스켈레톤 UI 추가
- 관심사 태그 가로 스크롤

<!-- PR 설명 -->

## Description
<img width="293" height="618" alt="스크린샷 2025-09-06 오전 12 20 55" src="https://github.com/user-attachments/assets/b7932158-4d06-4b3b-ab71-fc4491ce1437" />

- 추후 백엔드 api 연동 시 관심사 변경에 따라 api를 재호출해야하는데 이에 시간이 좀 걸릴 것이라 생각하여 사용자 경험을 개선하기 위해 스켈레톤 UI를 미리 구현해두었습니다.

## Category

- [x] 새로운 기능 추가 <!-- feat -->
- [ ] 버그 수정 <!-- fix -->
- [ ] UI/UX 변경 <!-- style -->
- [ ] 코드 리팩토링 <!-- refactor -->
- [ ] 주석/문서 수정 <!-- docs -->
- [ ] 테스트 추가/수정 <!-- test -->
- [ ] 빌드/패키지 매니저 변경 <!-- build -->
- [ ] 파일/폴더명 수정 <!-- chore -->
- [ ] 파일/폴더 삭제 <!-- chore -->

## Checklist

- [x] 커밋 메시지 컨벤션 준수
- [x] 변경 사항 테스트 완료
